### PR TITLE
Save value of X-Request-Id header from response

### DIFF
--- a/src/Exceptions/TransportException.php
+++ b/src/Exceptions/TransportException.php
@@ -13,5 +13,22 @@ namespace Hitmeister\Component\Api\Exceptions;
  */
 class TransportException extends \Exception implements ApiException
 {
+    /** @var  string */
+    protected $requestId = '';
 
+    /**
+     * @return string
+     */
+    public function getRequestId()
+    {
+        return $this->requestId;
+    }
+
+    /**
+     * @param string $requestId
+     */
+    public function setRequestId($requestId)
+    {
+        $this->requestId = $requestId;
+    }
 }

--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -85,17 +85,22 @@ class Middleware
 					// It is possible to ignore some status codes
 					if (!in_array($response['status'], $ignore)) {
 						// Is there any message?
-						$message = isset($response['json']['message']) ? $response['json']['message'] : 'Unknown error';
 
 						if ($response['status'] >= 400 && $response['status'] < 500) {
+							$message = isset($response['json']['message']) ? $response['json']['message'] : 'Unknown error';
 							if (404 == $response['status']) {
 								$exception = new ResourceNotFoundException();
 							} else {
 								$exception = new BadRequestException($message, $response['status']);
 							}
 						} else {
+							$message = isset($response['json']['message']) ? $response['json']['message'] : 'Internal Server Error';
 							$exception = new ServerException($message, $response['status']);
 						}
+
+						// Save unique request ID to the exception
+						$requestId = isset($response['headers']['X-Request-ID'][0]) ? $response['headers']['X-Request-ID'][0] : '';
+						$exception->setRequestId($requestId);
 
 						Logger::logState($logger, $request, $response, $exception, LogLevel::ERROR);
 						throw $exception;

--- a/tests/Exceptions/TransportExceptionTest.php
+++ b/tests/Exceptions/TransportExceptionTest.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace Hitmeister\Component\Api\Tests\Exceptions;
+
+use Hitmeister\Component\Api\Exceptions\TransportException;
+
+class TransportExceptionTest extends \PHPUnit_Framework_TestCase
+{
+	public function testRequestIdProperty()
+	{
+		$e = new TransportException('Test');
+		$this->assertEmpty($e->getRequestId());
+
+		$e->setRequestId('foo');
+		$this->assertEquals('foo', $e->getRequestId());
+
+		$e->setRequestId('bar');
+		$this->assertNotEquals('foo', $e->getRequestId());
+	}
+}

--- a/tests/Middleware/ProcessResponseTest.php
+++ b/tests/Middleware/ProcessResponseTest.php
@@ -4,6 +4,7 @@ namespace Hitmeister\Component\Api\Tests\Middleware;
 
 use GuzzleHttp\Ring\Future\CompletedFutureArray;
 use GuzzleHttp\Ring\Future\FutureArray;
+use Hitmeister\Component\Api\Exceptions\TransportException;
 use Hitmeister\Component\Api\Middleware;
 
 /**
@@ -277,5 +278,32 @@ class ProcessResponseTest extends \PHPUnit_Framework_TestCase
 		$this->assertJson($result['body']);
 		$this->assertArrayHasKey('json', $result);
 		$this->assertNotNull($result['json']);
+	}
+
+	public function testRequestIdInException()
+	{
+		$this->response['status'] = 444;
+		$this->response['headers'] = [
+			'X-Request-ID' => [
+				'ololo'
+			],
+		];
+
+		$request = [
+			'http_method' => 'PUT',
+			'headers'     => [],
+		];
+
+		$ff = $this->futureFunc;
+		$handler = $ff($this->response);
+		$middleware = Middleware::processResponse($handler, $this->logger);
+
+		try {
+			/** @var FutureArray $future */
+			$future = $middleware($request);
+			$result = $future->wait();
+		} catch (TransportException $e) {
+			$this->assertEquals('ololo', $e->getRequestId());
+		}
 	}
 }

--- a/tests/Middleware/ProcessResponseTest.php
+++ b/tests/Middleware/ProcessResponseTest.php
@@ -282,10 +282,11 @@ class ProcessResponseTest extends \PHPUnit_Framework_TestCase
 
 	public function testRequestIdInException()
 	{
+		$requestId = 'ololo';
 		$this->response['status'] = 444;
 		$this->response['headers'] = [
 			'X-Request-ID' => [
-				'ololo'
+				$requestId
 			],
 		];
 
@@ -303,7 +304,7 @@ class ProcessResponseTest extends \PHPUnit_Framework_TestCase
 			$future = $middleware($request);
 			$result = $future->wait();
 		} catch (TransportException $e) {
-			$this->assertEquals('ololo', $e->getRequestId());
+			$this->assertEquals($requestId, $e->getRequestId());
 		}
 	}
 }


### PR DESCRIPTION
From now on server generates unique ID for each request. Having this ID it would be much easier to track errors and analyze problems with API.