### PR TITLE
Dev 9086 add forgotten endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All Notable changes to `Hitmeister - API SDK for PHP` will be documented in this file.
 
+## 1.20.0 - 2018-04-23
+
+### Added
+
+- `/return-units/{id_return_unit}/clarify` endpoint
+- `/return-units/{id_return_unit}/repair` endpoint
+- `/order_units/{id_order_unit}/fulfil` endpoint
+
+
 ## 1.19.2 - 2018-04-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All Notable changes to `Hitmeister - API SDK for PHP` will be documented in this file.
 
-## 1.20.0 - 2018-04-23
+## 1.21.0 - 2018-04-23
 
 ### Added
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "hitmeister/api-sdk",
 	"description": "Real.de onlineshop API SDK for PHP",
 	"type": "library",
-	"version": "1.20.0",
+	"version": "1.21.0",
 	"authors": [
 		{
 			"name": "Real.de Onlineshop Developers",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "hitmeister/api-sdk",
 	"description": "Real.de onlineshop API SDK for PHP",
 	"type": "library",
-	"version": "1.19.2",
+	"version": "1.20.0",
 	"authors": [
 		{
 			"name": "Real.de Onlineshop Developers",
@@ -14,7 +14,10 @@
 	"keywords": [
 		"hitmeister",
 		"sdk",
-		"api"
+		"api",
+		"real.de",
+		"real.digital",
+		"real-digital"
 	],
 	"homepage": "https://www.real.de/api/v1/",
 	"support": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -35,7 +35,7 @@ use Hitmeister\Component\Api\Transport\Transport;
  */
 class Client
 {
-	const VERSION = '1.20.0';
+	const VERSION = '1.21.0';
 
 	/** @var Transport */
 	private $transport;

--- a/src/Client.php
+++ b/src/Client.php
@@ -35,7 +35,7 @@ use Hitmeister\Component\Api\Transport\Transport;
  */
 class Client
 {
-	const VERSION = '1.19.2';
+	const VERSION = '1.20.0';
 
 	/** @var Transport */
 	private $transport;

--- a/src/Endpoints/OrderUnits/Fulfil.php
+++ b/src/Endpoints/OrderUnits/Fulfil.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Hitmeister\Component\Api\Endpoints\OrderUnits;
+
+use Hitmeister\Component\Api\Endpoints\AbstractEndpoint;
+use Hitmeister\Component\Api\Endpoints\Interfaces\IdAware;
+use Hitmeister\Component\Api\Endpoints\Traits\EmptyParamWhiteList;
+use Hitmeister\Component\Api\Endpoints\Traits\RequestPatch;
+use Hitmeister\Component\Api\Endpoints\Traits\UriPatternId;
+
+class Fulfil extends AbstractEndpoint implements IdAware
+{
+	use RequestPatch;
+	use UriPatternId;
+	use EmptyParamWhiteList;
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function getUriPattern()
+	{
+		return 'order-units/%d/fulfil/';
+	}
+}

--- a/src/Endpoints/OrderUnits/Fulfil.php
+++ b/src/Endpoints/OrderUnits/Fulfil.php
@@ -8,6 +8,15 @@ use Hitmeister\Component\Api\Endpoints\Traits\EmptyParamWhiteList;
 use Hitmeister\Component\Api\Endpoints\Traits\RequestPatch;
 use Hitmeister\Component\Api\Endpoints\Traits\UriPatternId;
 
+/**
+ * Class Fulfil
+ *
+ * @category PHP-SDK
+ * @package  Hitmeister\Component\Api\Endpoints\OrderUnits
+ * @author   Oleksandr Dombrovskyi <oleksandr.dombrovskyi@real-digital.de>
+ * @license  https://opensource.org/licenses/MIT MIT
+ * @link     https://www.hitmeister.de/api/v1/
+ */
 class Fulfil extends AbstractEndpoint implements IdAware
 {
 	use RequestPatch;

--- a/src/Endpoints/ReturnUnits/Clarify.php
+++ b/src/Endpoints/ReturnUnits/Clarify.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Hitmeister\Component\Api\Endpoints\ReturnUnits;
+
+use Hitmeister\Component\Api\Endpoints\AbstractEndpoint;
+use Hitmeister\Component\Api\Endpoints\Interfaces\IdAware;
+use Hitmeister\Component\Api\Endpoints\Traits\BodyTransfer;
+use Hitmeister\Component\Api\Endpoints\Traits\EmptyParamWhiteList;
+use Hitmeister\Component\Api\Endpoints\Traits\RequestPatch;
+use Hitmeister\Component\Api\Endpoints\Traits\UriPatternId;
+use Hitmeister\Component\Api\Transfers\ReturnUnitClarifyTransfer;
+
+/**
+ * Class Clarify
+ *
+ * @category PHP-SDK
+ * @package  Hitmeister\Component\Api\Endpoints\ReturnUnits
+ * @author   Philipp Schreiber <philipp.schreiber@real-digital.de>
+ * @license  https://opensource.org/licenses/MIT MIT
+ * @link     https://www.hitmeister.de/api/v1/
+ */
+class Clarify extends AbstractEndpoint implements IdAware
+{
+    use RequestPatch;
+    use UriPatternId;
+    use EmptyParamWhiteList;
+    use BodyTransfer;
+
+    /**
+     * @param ReturnUnitClarifyTransfer $transfer
+     */
+    public function setTransfer(ReturnUnitClarifyTransfer $transfer)
+    {
+        $this->transfer = $transfer;
+    }
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function getUriPattern()
+	{
+		return 'return-units/%d/clarify/';
+	}
+}

--- a/src/Endpoints/ReturnUnits/Clarify.php
+++ b/src/Endpoints/ReturnUnits/Clarify.php
@@ -15,7 +15,7 @@ use Hitmeister\Component\Api\Transfers\ReturnUnitClarifyTransfer;
  *
  * @category PHP-SDK
  * @package  Hitmeister\Component\Api\Endpoints\ReturnUnits
- * @author   Philipp Schreiber <philipp.schreiber@real-digital.de>
+ * @author   Oleksandr Dombrovskyi <oleksandr.dombrovskyi@real-digital.de>
  * @license  https://opensource.org/licenses/MIT MIT
  * @link     https://www.hitmeister.de/api/v1/
  */

--- a/src/Endpoints/ReturnUnits/Clarify.php
+++ b/src/Endpoints/ReturnUnits/Clarify.php
@@ -34,11 +34,11 @@ class Clarify extends AbstractEndpoint implements IdAware
         $this->transfer = $transfer;
     }
 
-	/**
-	 * {@inheritdoc}
-	 */
-	protected function getUriPattern()
-	{
-		return 'return-units/%d/clarify/';
-	}
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUriPattern()
+    {
+        return 'return-units/%d/clarify/';
+    }
 }

--- a/src/Namespaces/OrderUnitsNamespace.php
+++ b/src/Namespaces/OrderUnitsNamespace.php
@@ -5,6 +5,7 @@ namespace Hitmeister\Component\Api\Namespaces;
 use Hitmeister\Component\Api\Cursor;
 use Hitmeister\Component\Api\Endpoints\OrderUnits\Cancel;
 use Hitmeister\Component\Api\Endpoints\OrderUnits\Find;
+use Hitmeister\Component\Api\Endpoints\OrderUnits\Fulfil;
 use Hitmeister\Component\Api\Endpoints\OrderUnits\Get;
 use Hitmeister\Component\Api\Endpoints\OrderUnits\Refund;
 use Hitmeister\Component\Api\Endpoints\OrderUnits\Send;
@@ -115,7 +116,7 @@ class OrderUnitsNamespace extends AbstractNamespace
 	}
 
 	/**
-	 * @param  int        $id
+	 * @param int         $id
 	 * @param string|null $carrierCode
 	 * @param string|null $trackingNumber
 	 * @return bool
@@ -144,8 +145,8 @@ class OrderUnitsNamespace extends AbstractNamespace
 	}
 
 	/**
-	 * @param  int $id
-	 * @param int  $amount
+	 * @param int    $id
+	 * @param int    $amount
 	 * @param string $reason
 	 *
 	 * @return bool
@@ -161,6 +162,25 @@ class OrderUnitsNamespace extends AbstractNamespace
 		$endpoint = new Refund($this->getTransport());
 		$endpoint->setId($id);
 		$endpoint->setTransfer($data);
+
+		try {
+			$result = $endpoint->performRequest();
+		} catch (ResourceNotFoundException $e) {
+			return false;
+		}
+
+		return $result['status'] == 204;
+	}
+
+	/**
+	 * @param int $id
+	 *
+	 * @return bool
+	 */
+	public function fulfil($id)
+	{
+		$endpoint = new Fulfil($this->getTransport());
+		$endpoint->setId($id);
 
 		try {
 			$result = $endpoint->performRequest();

--- a/src/Namespaces/ReturnUnitsNamespace.php
+++ b/src/Namespaces/ReturnUnitsNamespace.php
@@ -4,12 +4,15 @@ namespace Hitmeister\Component\Api\Namespaces;
 
 use Hitmeister\Component\Api\Cursor;
 use Hitmeister\Component\Api\Endpoints\ReturnUnits\Accept;
+use Hitmeister\Component\Api\Endpoints\ReturnUnits\Clarify;
 use Hitmeister\Component\Api\Endpoints\ReturnUnits\Find;
 use Hitmeister\Component\Api\Endpoints\ReturnUnits\Get;
 use Hitmeister\Component\Api\Endpoints\ReturnUnits\Reject;
+use Hitmeister\Component\Api\Endpoints\ReturnUnits\Repair;
 use Hitmeister\Component\Api\Exceptions\ResourceNotFoundException;
 use Hitmeister\Component\Api\FindBuilder;
 use Hitmeister\Component\Api\Namespaces\Traits\PerformWithId;
+use Hitmeister\Component\Api\Transfers\ReturnUnitClarifyTransfer;
 use Hitmeister\Component\Api\Transfers\ReturnUnitRejectTransfer;
 use Hitmeister\Component\Api\Transfers\ReturnUnitTransfer;
 use Hitmeister\Component\Api\Transfers\ReturnUnitWithEmbeddedTransfer;
@@ -120,4 +123,46 @@ class ReturnUnitsNamespace extends AbstractNamespace
 
 		return $result['status'] == 204;
 	}
+
+    /**
+     * @param int $id
+     * @return bool
+     */
+    public function repair($id)
+    {
+        $endpoint = new Repair($this->getTransport());
+        $endpoint->setId($id);
+
+        try {
+            $result = $endpoint->performRequest();
+        } catch (ResourceNotFoundException $e) {
+            return false;
+        }
+
+        return $result['status'] == 204;
+    }
+
+    /**
+     * @param int $id
+     * @param string $message
+     *
+     * @return bool
+     */
+    public function clarify($id, $message)
+    {
+        $data = new ReturnUnitClarifyTransfer();
+        $data->message = $message;
+
+        $endpoint = new Clarify($this->getTransport());
+        $endpoint->setId($id);
+        $endpoint->setTransfer($data);
+
+        try {
+            $result = $endpoint->performRequest();
+        } catch (ResourceNotFoundException $e) {
+            return false;
+        }
+
+        return $result['status'] == 204;
+    }
 }

--- a/src/Transfers/Constants.php
+++ b/src/Transfers/Constants.php
@@ -225,6 +225,7 @@ class Constants
     const STATUS_RETURN_REJECTED = 'return_rejected';
     const STATUS_RETURN_CLOSED = 'return_closed';
     const STATUS_RETURN_IN_REPAIR = 'return_in_repair';
+    const STATUS_RETURN_IN_CLARIFICATION = 'return_in_clarification';
     const REASON_RETURN = 'return';
     const REASON_OTHER = 'other';
     const REASON_NO_REASON = 'no_reason';

--- a/src/Transfers/ReturnUnitClarifyTransfer.php
+++ b/src/Transfers/ReturnUnitClarifyTransfer.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Hitmeister\Component\Api\Transfers;
+
+/**
+ * This class was auto generated. Please, do not modify it!
+ *
+ * @codeCoverageIgnore
+ *
+ * @property string $message
+ *
+ *
+ */
+class ReturnUnitClarifyTransfer extends AbstractTransfer
+{
+    /**
+     * @return array
+     */
+    public function getProperties()
+    {
+        static $properties = array (
+  'message' => 
+  array (
+    'embedded' => false,
+    'is_multiple' => false,
+  ),
+);
+        return $properties;
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return ReturnUnitClarifyTransfer
+     */
+    public static function make(array $data)
+    {
+        return AbstractTransfer::makeTransfer('Hitmeister\Component\Api\Transfers\ReturnUnitClarifyTransfer', $data);
+    }
+}

--- a/src/Transfers/UnitSellerTransfer.php
+++ b/src/Transfers/UnitSellerTransfer.php
@@ -20,6 +20,8 @@ namespace Hitmeister\Component\Api\Transfers;
  * @property int $reference_price
  * @property SellerTransfer $seller
  * @property int $shipping_rate
+ * @property string $date_inserted
+ * @property string $date_lastchange
  * @property int $listing_price
  * @property int $minimum_price
  * @property string $id_offer
@@ -97,6 +99,16 @@ class UnitSellerTransfer extends AbstractTransfer
     'type' => 'Hitmeister\\Component\\Api\\Transfers\\SellerTransfer',
   ),
   'shipping_rate' => 
+  array (
+    'embedded' => false,
+    'is_multiple' => false,
+  ),
+  'date_inserted' => 
+  array (
+    'embedded' => false,
+    'is_multiple' => false,
+  ),
+  'date_lastchange' => 
   array (
     'embedded' => false,
     'is_multiple' => false,

--- a/src/Transfers/UnitTransfer.php
+++ b/src/Transfers/UnitTransfer.php
@@ -20,6 +20,8 @@ namespace Hitmeister\Component\Api\Transfers;
  * @property int $reference_price
  * @property SellerTransfer $seller
  * @property int $shipping_rate
+ * @property string $date_inserted
+ * @property string $date_lastchange
  *
  *
  */
@@ -93,6 +95,16 @@ class UnitTransfer extends AbstractTransfer
     'type' => 'Hitmeister\\Component\\Api\\Transfers\\SellerTransfer',
   ),
   'shipping_rate' => 
+  array (
+    'embedded' => false,
+    'is_multiple' => false,
+  ),
+  'date_inserted' => 
+  array (
+    'embedded' => false,
+    'is_multiple' => false,
+  ),
+  'date_lastchange' => 
   array (
     'embedded' => false,
     'is_multiple' => false,

--- a/src/Transfers/UnitWithEmbeddedTransfer.php
+++ b/src/Transfers/UnitWithEmbeddedTransfer.php
@@ -20,6 +20,8 @@ namespace Hitmeister\Component\Api\Transfers;
  * @property int $reference_price
  * @property SellerTransfer $seller
  * @property int $shipping_rate
+ * @property string $date_inserted
+ * @property string $date_lastchange
  *
  * @property ItemTransfer $item
  * @property int $listing_price
@@ -97,6 +99,16 @@ class UnitWithEmbeddedTransfer extends AbstractTransfer
     'type' => 'Hitmeister\\Component\\Api\\Transfers\\SellerTransfer',
   ),
   'shipping_rate' => 
+  array (
+    'embedded' => false,
+    'is_multiple' => false,
+  ),
+  'date_inserted' => 
+  array (
+    'embedded' => false,
+    'is_multiple' => false,
+  ),
+  'date_lastchange' => 
   array (
     'embedded' => false,
     'is_multiple' => false,

--- a/tests/Endpoints/OrderUnits/FulfilTest.php
+++ b/tests/Endpoints/OrderUnits/FulfilTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Hitmeister\Component\Api\Tests\Endpoints\OrderUnits;
+
+use Hitmeister\Component\Api\Endpoints\OrderUnits\Fulfil;
+use Hitmeister\Component\Api\Tests\TransportAwareTestCase;
+
+class FulfilTest extends TransportAwareTestCase
+{
+    public function testInstance()
+    {
+        $endpoint = new Fulfil($this->transport);
+        $endpoint->setId(10);
+        $this->assertEquals(10, $endpoint->getId());
+        $this->assertEquals([], $endpoint->getParamWhiteList());
+        $this->assertEquals('PATCH', $endpoint->getMethod());
+        $this->assertEquals('order-units/10/fulfil/', $endpoint->getURI());
+    }
+
+    /**
+     * @expectedException \Hitmeister\Component\Api\Exceptions\RuntimeException
+     * @expectedExceptionMessage Required params id is not set
+     */
+    public function testExceptionOnEmptyId()
+    {
+        $endpoint = new Fulfil($this->transport);
+        $endpoint->getURI();
+    }
+}

--- a/tests/Endpoints/OrderUnits/FulfilTest.php
+++ b/tests/Endpoints/OrderUnits/FulfilTest.php
@@ -5,6 +5,15 @@ namespace Hitmeister\Component\Api\Tests\Endpoints\OrderUnits;
 use Hitmeister\Component\Api\Endpoints\OrderUnits\Fulfil;
 use Hitmeister\Component\Api\Tests\TransportAwareTestCase;
 
+/**
+ * Class FulfilTest
+ *
+ * @category PHP-SDK
+ * @package  Hitmeister\Component\Api\Tests\Endpoints\OrderUnits
+ * @author   Oleksandr Dombrovskyi <oleksandr.dombrovskyi@real-digital.de>
+ * @license  https://opensource.org/licenses/MIT MIT
+ * @link     https://www.hitmeister.de/api/v1/
+ */
 class FulfilTest extends TransportAwareTestCase
 {
     public function testInstance()

--- a/tests/Endpoints/ReturnUnits/ClarifyTest.php
+++ b/tests/Endpoints/ReturnUnits/ClarifyTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Hitmeister\Component\Api\Tests\Endpoints\ReturnUnits;
+
+use Hitmeister\Component\Api\Endpoints\ReturnUnits\Clarify;
+use Hitmeister\Component\Api\Tests\TransportAwareTestCase;
+
+/**
+ * Class AcceptTest
+ *
+ * @category PHP-SDK
+ * @package  Hitmeister\Component\Api\Tests\Endpoints\ReturnUnits
+ * @author   Philipp Schreiber <philipp.schreiber@real-digital.de>
+ * @license  https://opensource.org/licenses/MIT MIT
+ * @link     https://www.hitmeister.de/api/v1/
+ */
+class ClarifyTest extends TransportAwareTestCase
+{
+	public function testInstance()
+	{
+		$repair = new Clarify($this->transport);
+		$repair->setId(10);
+		$this->assertEquals(10, $repair->getId());
+		$this->assertEquals([], $repair->getParamWhiteList());
+		$this->assertEquals('PATCH', $repair->getMethod());
+		$this->assertEquals('return-units/10/clarify/', $repair->getURI());
+	}
+
+	/**
+	 * @expectedException \Hitmeister\Component\Api\Exceptions\RuntimeException
+	 * @expectedExceptionMessage Required params id is not set
+	 */
+	public function testExceptionOnEmptyId()
+	{
+		$get = new Clarify($this->transport);
+		$get->getURI();
+	}
+}

--- a/tests/Endpoints/ReturnUnits/ClarifyTest.php
+++ b/tests/Endpoints/ReturnUnits/ClarifyTest.php
@@ -6,7 +6,7 @@ use Hitmeister\Component\Api\Endpoints\ReturnUnits\Clarify;
 use Hitmeister\Component\Api\Tests\TransportAwareTestCase;
 
 /**
- * Class AcceptTest
+ * Class ClarifyTest
  *
  * @category PHP-SDK
  * @package  Hitmeister\Component\Api\Tests\Endpoints\ReturnUnits

--- a/tests/Endpoints/ReturnUnits/ClarifyTest.php
+++ b/tests/Endpoints/ReturnUnits/ClarifyTest.php
@@ -10,7 +10,7 @@ use Hitmeister\Component\Api\Tests\TransportAwareTestCase;
  *
  * @category PHP-SDK
  * @package  Hitmeister\Component\Api\Tests\Endpoints\ReturnUnits
- * @author   Philipp Schreiber <philipp.schreiber@real-digital.de>
+ * @author   Oleksandr Dombrovskyi <oleksandr.dombrovskyi@real-digital.de>
  * @license  https://opensource.org/licenses/MIT MIT
  * @link     https://www.hitmeister.de/api/v1/
  */

--- a/tests/Endpoints/ReturnUnits/RepairTest.php
+++ b/tests/Endpoints/ReturnUnits/RepairTest.php
@@ -6,7 +6,7 @@ use Hitmeister\Component\Api\Endpoints\ReturnUnits\Repair;
 use Hitmeister\Component\Api\Tests\TransportAwareTestCase;
 
 /**
- * Class AcceptTest
+ * Class RepairTest
  *
  * @category PHP-SDK
  * @package  Hitmeister\Component\Api\Tests\Endpoints\ReturnUnits

--- a/tests/Namespaces/OrderUnitsNamespaceTest.php
+++ b/tests/Namespaces/OrderUnitsNamespaceTest.php
@@ -140,4 +140,24 @@ class OrderUnitsNamespaceTest extends TransportAwareTestCase
 		$this->assertTrue($result);
 	}
 
+	public function testFulfil()
+	{
+		$this->transport->shouldReceive('performRequest')->once()->andReturn([
+			'status' => 204,
+		]);
+
+		$namespace = new OrderUnitsNamespace($this->transport);
+		$result = $namespace->fulfil(10);
+		$this->assertTrue($result);
+	}
+
+	public function testFulfilNotFound()
+	{
+		$this->transport->shouldReceive('performRequest')->once()->andThrow(new ResourceNotFoundException());
+
+		$namespace = new OrderUnitsNamespace($this->transport);
+		$result = $namespace->fulfil(10);
+		$this->assertFalse($result);
+	}
+
 }

--- a/tests/Namespaces/ReturnUnitsNamespaceTest.php
+++ b/tests/Namespaces/ReturnUnitsNamespaceTest.php
@@ -129,4 +129,44 @@ class ReturnUnitsNamespaceTest extends TransportAwareTestCase
 		$result = $namespace->reject(10, 'message');
 		$this->assertFalse($result);
 	}
+
+	public function testRepair()
+	{
+		$this->transport->shouldReceive('performRequest')->once()->andReturn([
+			'status' => 204,
+		]);
+
+		$namespace = new ReturnUnitsNamespace($this->transport);
+		$result = $namespace->repair(10);
+		$this->assertTrue($result);
+	}
+
+	public function testRepairNotFound()
+	{
+		$this->transport->shouldReceive('performRequest')->once()->andThrow(new ResourceNotFoundException());
+
+		$namespace = new ReturnUnitsNamespace($this->transport);
+		$result = $namespace->repair(10);
+		$this->assertFalse($result);
+	}
+
+	public function testClarify()
+	{
+		$this->transport->shouldReceive('performRequest')->once()->andReturn([
+			'status' => 204,
+		]);
+
+		$namespace = new ReturnUnitsNamespace($this->transport);
+		$result = $namespace->clarify(10, 'message');
+		$this->assertTrue($result);
+	}
+
+	public function testClarifyNotFound()
+	{
+		$this->transport->shouldReceive('performRequest')->once()->andThrow(new ResourceNotFoundException());
+
+		$namespace = new ReturnUnitsNamespace($this->transport);
+        $result = $namespace->clarify(10, 'message');
+		$this->assertFalse($result);
+	}
 }


### PR DESCRIPTION
### Added

- `/return-units/{id_return_unit}/clarify` endpoint
- `/return-units/{id_return_unit}/repair` endpoint
- `/order_units/{id_order_unit}/fulfil` endpoint
- `date_insterted` field to UnitSellerTransfer, UnitWithEmbeddedTransfer, UnitTransfer
- `date_lastchange` field to UnitSellerTransfer, UnitWithEmbeddedTransfer, UnitTransfer

### Updated 
- keywords in composer.json
