### PR TITLE
DEV-9378: download ticket files without being logged in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All Notable changes to `Hitmeister - API SDK for PHP` will be documented in this file.
 
+## 1.22.0 - 2018-04-28
+
+### Updated
+
+- New format for field `uri` when requesting ticket files via `/tickets/getTicket{id_ticket}`. Now the
+  absolute uri for the given file is returned alongside with a key, so file downloading is possible without being
+  logged in.
+
 ## 1.21.0 - 2018-04-23
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "hitmeister/api-sdk",
     "description": "Real.de onlineshop API SDK for PHP",
     "type": "library",
-    "version": "1.21.0",
+    "version": "1.22.0",
     "authors": [
         {
             "name": "Real.de Onlineshop Developers",

--- a/src/Client.php
+++ b/src/Client.php
@@ -35,7 +35,7 @@ use Hitmeister\Component\Api\Transport\Transport;
  */
 class Client
 {
-	const VERSION = '1.21.0';
+	const VERSION = '1.22.0';
 
 	/** @var Transport */
 	private $transport;


### PR DESCRIPTION
**Updated**

- New format for field `uri` when requesting ticket files via
`/tickets/getTicket{id_ticket}`. Now the absolute uri is returned
alongside with a key so file downloading is possible without being
logged in.