### PR TITLE
DEV-9690: make refund reason required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All Notable changes to `Hitmeister - API SDK for PHP` will be documented in this file.
 
+## 1.22.1 - 2018-07-05
+
+### Fixed
+
+- The field `reason` is mandatory when sending a refund to the customer for a particular
+  order unit via `/order-units/{id_order_unit}/refund/`.
+
 ## 1.22.0 - 2018-04-28
 
 ### Updated

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "hitmeister/api-sdk",
     "description": "Real.de onlineshop API SDK for PHP",
     "type": "library",
-    "version": "1.22.0",
+    "version": "1.22.1",
     "authors": [
         {
             "name": "Real.de Onlineshop Developers",

--- a/src/Client.php
+++ b/src/Client.php
@@ -35,7 +35,7 @@ use Hitmeister\Component\Api\Transport\Transport;
  */
 class Client
 {
-	const VERSION = '1.22.0';
+	const VERSION = '1.22.1';
 
 	/** @var Transport */
 	private $transport;

--- a/tests/Endpoints/OrderUnits/RefundTest.php
+++ b/tests/Endpoints/OrderUnits/RefundTest.php
@@ -11,7 +11,7 @@ class RefundTest extends TransportAwareTestCase
 	{
 		/** @var \Mockery\Mock|\Hitmeister\Component\Api\Transfers\OrderUnitRefundTransfer $transfer */
 		$transfer = \Mockery::mock('\Hitmeister\Component\Api\Transfers\OrderUnitRefundTransfer');
-		$transfer->shouldReceive('toArray')->once()->andReturn(['amount' => 100500]);
+		$transfer->shouldReceive('toArray')->once()->andReturn(['amount' => 100500, 'reason' => 'other_refund']);
 
 		$send = new Refund($this->transport);
 		$send->setId(1);
@@ -23,6 +23,7 @@ class RefundTest extends TransportAwareTestCase
 
 		$body = $send->getBody();
 		$this->assertArrayHasKey('amount', $body);
+		$this->assertArrayHasKey('reason', $body);
 	}
 
 	/**


### PR DESCRIPTION
**Updated**

- The field `reason` is mandatory when sending a refund to the customer for a particular order unit via `/order-units/{id_order_unit}/refund/`.
