### PR TITLE
Changed UriPattern to string

### DIFF
--- a/src/Endpoints/ProductData/Upsert.php
+++ b/src/Endpoints/ProductData/Upsert.php
@@ -40,6 +40,6 @@ class Upsert extends AbstractEndpoint implements IdAware
 	 */
 	protected function getUriPattern()
 	{
-		return 'product-data/%d/';
+		return 'product-data/%s/';
 	}
 }


### PR DESCRIPTION
Using %d caused problems for 32-bit systems where long numbers (EAN-13) were overflowing into a lower number. Using %s prevents this issue.