### PR TITLE
Compatibility with HTTP/2

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -100,6 +100,9 @@ class Middleware
 
 						// Save unique request ID to the exception
 						$requestId = isset($response['headers']['X-Request-ID'][0]) ? $response['headers']['X-Request-ID'][0] : '';
+						if ($requestId === '') {
+							$requestId = isset($response['headers']['x-request-id'][0]) ? $response['headers']['x-request-id'][0] : '';
+						}
 						$exception->setRequestId($requestId);
 
 						Logger::logState($logger, $request, $response, $exception, LogLevel::ERROR);

--- a/src/Transport/RequestBuilder.php
+++ b/src/Transport/RequestBuilder.php
@@ -95,7 +95,6 @@ class RequestBuilder
 				'connect_timeout' => 30,
 				'timeout' => 60,
 			],
-			'version' => 1.1,
 		];
 
 		// Build query


### PR DESCRIPTION
Fixes #49.

Allows for HTTP/2 usage with the API. As this usually offers better performance as HTTP/1, this should be preferred. 

The code works with both version `1.1` and `2.0` hardcoded (as well as not defining the version). However, I've noticed the default being `1.1` in my tests, when I don't configure anything. So it's not defaulting to HTTP/2 anymore - I don't know why (perhaps a server configuration?). 

Anyhow, this should prove to be future-proof for now. 
