### PR TITLE
always add ShipmentInformationTransfer to OrderUnitShipmentTransfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All Notable changes to `Hitmeister - API SDK for PHP` will be documented in this file.
 
+## 1.35.1 - 2020-02-13
+
+### Fixed
+- Property `shipment_information` of `OrderUnitShipmentTransfer` should not be empty
+
 ## 1.35.0 - 2019-11-11
 
 ### Added

--- a/src/Client.php
+++ b/src/Client.php
@@ -37,7 +37,7 @@ use Hitmeister\Component\Api\Transport\Transport;
  */
 class Client
 {
-	const VERSION = '1.35.0';
+	const VERSION = '1.35.1';
 
 	/** @var Transport */
 	private $transport;

--- a/src/Namespaces/ShipmentsNamespace.php
+++ b/src/Namespaces/ShipmentsNamespace.php
@@ -28,11 +28,13 @@ class ShipmentsNamespace extends AbstractNamespace
 	 */
 	public function post($orderUnitId, $carrierCode, $trackingNumber)
 	{
+        $shipmentInformation = new ShipmentInformationTransfer();
+        $shipmentInformation->carrier_code = $carrierCode;
+        $shipmentInformation->tracking_number = $trackingNumber;
+
 		$data = new OrderUnitShipmentTransfer();
 		$data->id_order_unit = $orderUnitId;
-		$shipmentInformation = new ShipmentInformationTransfer();
-		$shipmentInformation->carrier_code = $carrierCode;
-		$shipmentInformation->tracking_number = $trackingNumber;
+		$data->shipment_information = $shipmentInformation;
 
 		$endpoint = new Post($this->getTransport());
 		$endpoint->setTransfer($data);

--- a/src/Namespaces/ShipmentsNamespace.php
+++ b/src/Namespaces/ShipmentsNamespace.php
@@ -28,9 +28,9 @@ class ShipmentsNamespace extends AbstractNamespace
 	 */
 	public function post($orderUnitId, $carrierCode, $trackingNumber)
 	{
-        $shipmentInformation = new ShipmentInformationTransfer();
-        $shipmentInformation->carrier_code = $carrierCode;
-        $shipmentInformation->tracking_number = $trackingNumber;
+		$shipmentInformation = new ShipmentInformationTransfer();
+		$shipmentInformation->carrier_code = $carrierCode;
+		$shipmentInformation->tracking_number = $trackingNumber;
 
 		$data = new OrderUnitShipmentTransfer();
 		$data->id_order_unit = $orderUnitId;


### PR DESCRIPTION
Fixed bug, when \Hitmeister\Component\Api\Transfers\OrderUnitShipmentTransfer::@$shipment_information is always empty