### PR TITLE
A EAN Value is currently treated as a numeric value when Client will render Uri for GET product-data-status/<ean> call

### DIFF
--- a/src/Endpoints/ProductDataStatus/Get.php
+++ b/src/Endpoints/ProductDataStatus/Get.php
@@ -28,6 +28,6 @@ class Get extends AbstractEndpoint implements IdAware
 	 */
 	protected function getUriPattern()
 	{
-		return 'product-data-status/%d/';
+		return 'product-data-status/%s/';
 	}
 }

--- a/tests/Endpoints/ProductDataStatus/GetTest.php
+++ b/tests/Endpoints/ProductDataStatus/GetTest.php
@@ -35,4 +35,14 @@ class GetTest extends TransportAwareTestCase
 		$get = new Get($this->transport);
 		$get->getURI();
 	}
+
+    public function testItWillUseEANAsStringWhenGetUri()
+    {
+        $expectedEan = '033200011101';
+
+        $sut = new Get($this->transport);
+        $sut->setId($expectedEan);
+
+        $this->assertEquals("product-data-status/{$expectedEan}/", $sut->getURI());
+    }
 }


### PR DESCRIPTION
When request a Product Data Status for a EAN with a leading 0 (zero) the current code will convert this to numeric representation an remove the leading zero, which cause a 404 response because a unknown or invalid EAN is checked.

Here is a fix. Would be happy to see it in it wild. 

Thanks ;)