### PR TITLE
Client.php returns the proper namespace when accessing ticket messages

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -293,11 +293,11 @@ class Client
 	}
 
 	/**
-	 * @return ClaimMessagesNamespace
+	 * @return TicketMessagesNamespace
 	 */
 	public function ticketMessages()
 	{
-		return $this->claimMessagesNs;
+		return $this->ticketMessagesNs;
 	}
 
 	/**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -37,5 +37,9 @@ class ClientTest extends TransportAwareTestCase
 		$this->assertInstanceOf('\Hitmeister\Component\Api\Namespaces\StatusNamespace', $client->status());
 		$this->assertInstanceOf('\Hitmeister\Component\Api\Namespaces\SubscriptionsNamespace', $client->subscriptions());
 		$this->assertInstanceOf('\Hitmeister\Component\Api\Namespaces\UnitsNamespace', $client->units());
+		$this->assertInstanceOf('\Hitmeister\Component\Api\Namespaces\TicketsNamespace', $client->tickets());
+		$this->assertInstanceOf('\Hitmeister\Component\Api\Namespaces\TicketMessagesNamespace', $client->ticketMessages());
+		$this->assertInstanceOf('\Hitmeister\Component\Api\Namespaces\OrderInvoicesNamespace', $client->orderInvoices());
+		$this->assertInstanceOf('\Hitmeister\Component\Api\Namespaces\WarehousesNamespace', $client->warehouses());
 	}
 }


### PR DESCRIPTION
I noticed that it is impossible to interact with ticket messages via the client because `ticketMessages()` returns a `ClaimMessagesNamespace`. I've fixed this and added a few more assertions to the ClientTest.php